### PR TITLE
Remove node checks from csproj

### DIFF
--- a/MyApp/MyApp.csproj
+++ b/MyApp/MyApp.csproj
@@ -19,9 +19,4 @@
     <ProjectReference Include="..\MyApp.ServiceModel\MyApp.ServiceModel.csproj" />
   </ItemGroup>
 
-  <Target Name="OnFirstUse" BeforeTargets="Build" Condition=" !Exists('wwwroot\dist') ">
-    <Exec Command="node --version" ContinueOnError="true"><Output TaskParameter="ExitCode" PropertyName="ErrorCode" /></Exec>
-    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
-  </Target>
-
 </Project>


### PR DESCRIPTION
Are these csproj based node checks useful for anything?
I was setting up a multi-stage docker build where the backend build stage doesn't have node installed (`FROM mcr.microsoft.com/dotnet/sdk:5.0`) and this threw me for a minute.